### PR TITLE
Add Java 11 String strip methods

### DIFF
--- a/src/main/java/net/raphimc/javadowngrader/transformer/j10/Java11ToJava10.java
+++ b/src/main/java/net/raphimc/javadowngrader/transformer/j10/Java11ToJava10.java
@@ -32,6 +32,10 @@ public class Java11ToJava10 extends DowngradingTransformer {
 
         this.addMethodCallReplacer(Opcodes.INVOKEVIRTUAL, "java/lang/String", "isBlank", "()Z", new StringIsBlankMCR());
 
+        this.addMethodCallReplacer(Opcodes.INVOKEVIRTUAL, "java/lang/String", "strip", "()Ljava/lang/String;", new StringStripMCR());
+        this.addMethodCallReplacer(Opcodes.INVOKEVIRTUAL, "java/lang/String", "stripLeading", "()Ljava/lang/String;", new StringStripLeadingMCR());
+        this.addMethodCallReplacer(Opcodes.INVOKEVIRTUAL, "java/lang/String", "stripTrailing", "()Ljava/lang/String;", new StringStripTrailingMCR());
+
         this.addMethodCallReplacer(Opcodes.INVOKESTATIC, "java/nio/file/Files", "readString", new FilesReadStringMCR());
 
         this.addMethodCallReplacer(Opcodes.INVOKESTATIC, "java/nio/file/Path", "of", new PathOfMCR());

--- a/src/main/java/net/raphimc/javadowngrader/transformer/j10/methodcallreplacer/StringStripLeadingMCR.java
+++ b/src/main/java/net/raphimc/javadowngrader/transformer/j10/methodcallreplacer/StringStripLeadingMCR.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of JavaDowngrader - https://github.com/RaphiMC/JavaDowngrader
+ * Copyright (C) 2023 RK_01/RaphiMC and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.raphimc.javadowngrader.transformer.j10.methodcallreplacer;
+
+import net.raphimc.javadowngrader.RuntimeDepCollector;
+import net.raphimc.javadowngrader.transformer.DowngradeResult;
+import net.raphimc.javadowngrader.transformer.MethodCallReplacer;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.*;
+
+public class StringStripLeadingMCR implements MethodCallReplacer {
+
+    @Override
+    public InsnList getReplacement(ClassNode classNode, MethodNode methodNode, String originalName, String originalDesc, RuntimeDepCollector depCollector, DowngradeResult result) {
+        final InsnList replacement = new InsnList();
+
+        // String
+        replacement.add(new LdcInsnNode("^\\s++"));
+        // String String
+        replacement.add(new LdcInsnNode(""));
+        // String String String
+        replacement.add(new MethodInsnNode(Opcodes.INVOKEVIRTUAL, "java/lang/String", "replaceFirst", "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;"));
+        // String
+
+        return replacement;
+    }
+
+}

--- a/src/main/java/net/raphimc/javadowngrader/transformer/j10/methodcallreplacer/StringStripMCR.java
+++ b/src/main/java/net/raphimc/javadowngrader/transformer/j10/methodcallreplacer/StringStripMCR.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of JavaDowngrader - https://github.com/RaphiMC/JavaDowngrader
+ * Copyright (C) 2023 RK_01/RaphiMC and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.raphimc.javadowngrader.transformer.j10.methodcallreplacer;
+
+import net.raphimc.javadowngrader.RuntimeDepCollector;
+import net.raphimc.javadowngrader.transformer.DowngradeResult;
+import net.raphimc.javadowngrader.transformer.MethodCallReplacer;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.*;
+
+public class StringStripMCR implements MethodCallReplacer {
+
+    @Override
+    public InsnList getReplacement(ClassNode classNode, MethodNode methodNode, String originalName, String originalDesc, RuntimeDepCollector depCollector, DowngradeResult result) {
+        final InsnList replacement = new InsnList();
+
+        // String
+        replacement.add(new LdcInsnNode("^\\s++|\\s++$"));
+        // String String
+        replacement.add(new LdcInsnNode(""));
+        // String String String
+        replacement.add(new MethodInsnNode(Opcodes.INVOKEVIRTUAL, "java/lang/String", "replaceAll", "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;"));
+        // String
+
+        return replacement;
+    }
+
+}

--- a/src/main/java/net/raphimc/javadowngrader/transformer/j10/methodcallreplacer/StringStripTrailingMCR.java
+++ b/src/main/java/net/raphimc/javadowngrader/transformer/j10/methodcallreplacer/StringStripTrailingMCR.java
@@ -1,0 +1,43 @@
+/*
+ * This file is part of JavaDowngrader - https://github.com/RaphiMC/JavaDowngrader
+ * Copyright (C) 2023 RK_01/RaphiMC and contributors
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package net.raphimc.javadowngrader.transformer.j10.methodcallreplacer;
+
+import net.raphimc.javadowngrader.RuntimeDepCollector;
+import net.raphimc.javadowngrader.transformer.DowngradeResult;
+import net.raphimc.javadowngrader.transformer.MethodCallReplacer;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.*;
+
+public class StringStripTrailingMCR implements MethodCallReplacer {
+
+    @Override
+    public InsnList getReplacement(ClassNode classNode, MethodNode methodNode, String originalName, String originalDesc, RuntimeDepCollector depCollector, DowngradeResult result) {
+        final InsnList replacement = new InsnList();
+
+        // String
+        replacement.add(new LdcInsnNode("\\s++$"));
+        // String String
+        replacement.add(new LdcInsnNode(""));
+        // String String String
+        replacement.add(new MethodInsnNode(Opcodes.INVOKEVIRTUAL, "java/lang/String", "replaceFirst", "(Ljava/lang/String;Ljava/lang/String;)Ljava/lang/String;"));
+        // String
+
+        return replacement;
+    }
+
+}


### PR DESCRIPTION
Add .strip(), .stripLeading(), and .stripTrailing()

Test results:

![image](https://github.com/RaphiMC/JavaDowngrader/assets/24785136/0e5b96a7-dac3-483c-a8e4-49d67b193575)
![image](https://github.com/RaphiMC/JavaDowngrader/assets/24785136/825d1168-d235-4f24-9c98-0c6dca306a62)
